### PR TITLE
channel arg and other fixes

### DIFF
--- a/scripts/Slack_Msg.py
+++ b/scripts/Slack_Msg.py
@@ -117,11 +117,6 @@ if (EnvData_dict["_SEVERITY"] == "CRITICAL"):
 
 #Here we will build the response
 response = requests.post( webhook_url, data=Send_Msg, headers={'Content-Type': 'application/json'} )
-if response.status_code != 200:
-    raise ValueError(
-        'Request to slack returned an error %s, the response is:\n%s'
-        % (response.status_code, response.text)
-    )
 
 # Writing the whole Env Vars to file for sanity checks
 if "_SLACK_MSG_RECEIPT" in EnvData_dict:
@@ -150,3 +145,9 @@ if "_SLACK_MSG_RECEIPT" in EnvData_dict:
     f.write('\n')
     #Close the file up
     f.close()
+
+if response.status_code != 200:
+    raise ValueError(
+        'Request to slack returned an error %s, the response is:\n%s'
+        % (response.status_code, response.text)
+    )

--- a/scripts/Slack_Msg.py
+++ b/scripts/Slack_Msg.py
@@ -22,6 +22,7 @@ parser = argparse.ArgumentParser( description = "Outbound SlackBot Integration" 
 
 # Typical operations for PagerDuty
 parser.add_argument( "-wh", "--webhook", help = "Webhook URL for sending message to",  type=str)
+parser.add_argument( "-ch", "--channel", help = "Slack Channel or user for sending message to",  type=str)
 
 # global args
 args = parser.parse_args()
@@ -31,9 +32,19 @@ if (args.webhook):
 else:
     webhook_url =  EnvData_dict["_SLACK_HOOK"]
 
+if (args.channel):
+    channel =  (args.channel)
+else:
+    channel =  EnvData_dict["_SLACK_CHANNEL"]
+
+if "_SLACK_BOTNAME" in EnvData_dict:
+    botname = EnvData_dict["_SLACK_BOTNAME"]
+else:
+    botname = 'Geneos_Slack_Alerts'
+
 #Building a Slack Pre-Reqs and the message
-Addressed_Channel_Msg = ("{\"channel\":\"" + EnvData_dict["_SLACK_CHANNEL"] + "\", "
-"\"username\":\"" + EnvData_dict["_SLACK_BOTNAME"] + "\", "
+Addressed_Channel_Msg = ("{\"channel\":\"" + channel + "\", "
+"\"username\":\"" + botname + "\", "
 "\"attachments\":[ ")
 
 # Time should be handled as so, YYYY-MM-DD


### PR DESCRIPTION
- Added Slack channel parameter to script. Script can be executed with this argument like so:
 `/appspace/itrs/gateway/gateway_scripts/Slack_Msg.py -ch channel-name -wh slack_hook_url`
- Some variable creation and usage, including with creating a generic default option for the bot name.
- Shifted the message receipt logic to occur before the status check. Allows message receipt to be output if the status code isn't 200 (useful for debugging).